### PR TITLE
Support for g++. Removed deprecated call to conio.h library

### DIFF
--- a/Muscle_Model/Makefile
+++ b/Muscle_Model/Makefile
@@ -1,0 +1,2 @@
+all:
+	g++ -o run generate_total_force.cpp MuscleModel.cpp -I. -std=c++11

--- a/Muscle_Model/generate_total_force.cpp
+++ b/Muscle_Model/generate_total_force.cpp
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <conio.h>
 
 const int SAMPLING_RATE = 1024;
 


### PR DESCRIPTION
Tested on Ubuntu 14.04 using g++ 4.9.2

![pullrequestscreenshot](https://cloud.githubusercontent.com/assets/6560695/10711260/8fd1070c-7a43-11e5-96ed-2a22708565f1.png)
